### PR TITLE
Update favicon considerations in config theme

### DIFF
--- a/docs/zh/configuration/README.md
+++ b/docs/zh/configuration/README.md
@@ -21,7 +21,7 @@ Hugo 的配置存放在站点根目录的 `config.yaml` 里（其实也可以使
 RSS 输出文章完整内容
 
 ### `favicon`
-站点的图标
+站点的图标。  注意在圖檔路徑前必須添加"/"否則會造成除了主頁以外的頁面無法顯示，例如`/img/favicon.png`
 
 <!-- footer
 ## footer


### PR DESCRIPTION
Update the notes about favicon in the configuration theme, "/" must be added before the image file path, otherwise pages other than the home page will not be displayed, such as `/img/favicon.png`

---

更新配置主題中關於favicon的注意事項，圖檔路徑前必須添加"/"否則會造成除了主頁以外的頁面無法顯示，例如`/img/favicon.png`